### PR TITLE
Fix BCC support

### DIFF
--- a/envelopes/conn.py
+++ b/envelopes/conn.py
@@ -85,7 +85,7 @@ class SMTP(object):
             self._connect()
 
         msg = envelope.to_mime_message()
-        to_addrs = envelope._to + envelope._cc + envelope._bcc
+        to_addrs = [envelope._addrs_to_header([addr]) for addr in envelope._to + envelope._cc + envelope._bcc]
 
         return self._conn.sendmail(msg['From'], to_addrs, msg.as_string())
 

--- a/envelopes/conn.py
+++ b/envelopes/conn.py
@@ -88,7 +88,6 @@ class SMTP(object):
         to_addrs = envelope._to + envelope._cc + envelope._bcc
 
         return self._conn.sendmail(msg['From'], to_addrs, msg.as_string())
-        #return self._conn.sendmail(msg['From'], msg['To'], msg.as_string())
 
 
 class GMailSMTP(SMTP):

--- a/envelopes/conn.py
+++ b/envelopes/conn.py
@@ -85,7 +85,9 @@ class SMTP(object):
             self._connect()
 
         msg = envelope.to_mime_message()
-        return self._conn.sendmail(msg['From'], msg['To'], msg.as_string())
+        to_addrs = envelope._to + envelope._cc + envelope._bcc
+
+        return self._conn.sendmail(msg['From'], to_addrs, msg.as_string())
 
 
 class GMailSMTP(SMTP):

--- a/envelopes/conn.py
+++ b/envelopes/conn.py
@@ -88,6 +88,7 @@ class SMTP(object):
         to_addrs = envelope._to + envelope._cc + envelope._bcc
 
         return self._conn.sendmail(msg['From'], to_addrs, msg.as_string())
+        #return self._conn.sendmail(msg['From'], msg['To'], msg.as_string())
 
 
 class GMailSMTP(SMTP):

--- a/envelopes/envelope.py
+++ b/envelopes/envelope.py
@@ -111,12 +111,18 @@ class Envelope(object):
             self._parts.append(('text/html', html_body, charset))
 
         if cc_addr:
-            self._cc = cc_addr
+            if isinstance(cc_addr, list):
+                self._cc = cc_addr
+            else:
+                self._cc = [cc_addr]
         else:
             self._cc = []
 
         if bcc_addr:
-            self._bcc = bcc_addr
+            if isinstance(bcc_addr, list):
+                self._bcc = bcc_addr
+            else:
+                self._bcc = [bcc_addr]
         else:
             self._bcc = []
 
@@ -275,9 +281,6 @@ class Envelope(object):
 
         if self._cc:
             msg['CC'] = self._addrs_to_header(self._cc)
-
-        if self._bcc:
-            msg['BCC'] = self._addrs_to_header(self._bcc)
 
         if self._headers:
             for key, value in self._headers.items():

--- a/envelopes/envelope.py
+++ b/envelopes/envelope.py
@@ -80,8 +80,8 @@ class Envelope(object):
     :param subject: message subject
     :param html_body: optional HTML part of the message
     :param text_body: optional plain text part of the message
-    :param cc_addrs: optional list of CC address
-    :param bcc_addrs: optional list of BCC address
+    :param cc_addr: optional single CC address or list of CC addresses
+    :param bcc_addr: optional single BCC address or list of BCC addresses
     :param headers: optional dictionary of headers
     :param charset: message charset
     """

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -137,5 +137,5 @@ class Test_SMTPConnection(BaseTestCase):
         call_args = conn._conn._call_stack['sendmail'][0][0]
         assert len(call_args) == 3
         assert call_args[0] == mime_msg['From']
-        assert call_args[1] == mime_msg['To']
+        assert call_args[1] == envelope._to + envelope._cc + envelope._bcc
         assert call_args[2] != ''

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -137,5 +137,5 @@ class Test_SMTPConnection(BaseTestCase):
         call_args = conn._conn._call_stack['sendmail'][0][0]
         assert len(call_args) == 3
         assert call_args[0] == mime_msg['From']
-        assert call_args[1] == envelope._to + envelope._cc + envelope._bcc
+        assert call_args[1] == [envelope._addrs_to_header([addr]) for addr in envelope._to + envelope._cc + envelope._bcc]
         assert call_args[2] != ''

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -124,13 +124,7 @@ class Test_Envelope(BaseTestCase):
             'Example CC3 <cc3@example.com>'
         )
         assert mime_msg['CC'] == cc_header
-
-        bcc_header = (
-            'bcc1@example.com,'
-            'Example BCC2 <bcc2@example.com>,'
-            'Example BCC3 <bcc3@example.com>'
-        )
-        assert mime_msg['BCC'] == bcc_header
+        assert 'BCC' not in mime_msg
 
         assert mime_msg['Reply-To'] == msg['headers']['Reply-To']
         assert mime_msg['X-Mailer'] == msg['headers']['X-Mailer']
@@ -213,7 +207,7 @@ class Test_Envelope(BaseTestCase):
 
         assert mime_msg['CC'] == enc_addr_header(u'ęóąśłżźćń', '<cc@example.com>')
 
-        assert mime_msg['BCC'] == enc_addr_header(u'ęóąśłżźćń', '<bcc@example.com>')
+        assert 'BCC' not in mime_msg
 
         assert mime_msg['X-Test'] == Header(msg['headers']['X-Test'], 'utf-8').encode()
 


### PR DESCRIPTION
The major fix in this pull request is to fix support for BCC emails.  CC and BCC addresses should be added to the to_addrs parameter in the call to SMTP.sendmail() to ensure delivery.  CC addresses were correctly being added to the SMTP headers, however BCC addresses were being incorrectly added.  To preserve anonymity, BCC addresses should be excluded here.
