### PR TITLE
Change default GMail SMTP/TLS port to 587.

### DIFF
--- a/envelopes/conn.py
+++ b/envelopes/conn.py
@@ -95,11 +95,13 @@ class GMailSMTP(SMTP):
 
     GMAIL_SMTP_HOST = 'smtp.googlemail.com'
     GMAIL_SMTP_TLS = True
+    GMAIL_SMTP_PORT = 587
 
     def __init__(self, login=None, password=None):
         super(GMailSMTP, self).__init__(
-            self.GMAIL_SMTP_HOST, tls=self.GMAIL_SMTP_TLS, login=login,
-            password=password
+            self.GMAIL_SMTP_HOST, port=self.GMAIL_SMTP_PORT,
+            tls=self.GMAIL_SMTP_TLS,
+            login=login, password=password
         )
 
 


### PR DESCRIPTION
In testing, the default of '25' doesn't work for me.

Google's support page at
https://support.google.com/mail/answer/78775?hl=en
says the following:

```
If you tried configuring your SMTP server on port 465 (with SSL)
and port 587 (with TLS), but are still having trouble sending mail,
try configuring your SMTP to use port 25 (with SSL).
```

Which is a bit unclear but suggests 587 is sensible.

Perhaps my (university) institution has firewalled port 25, 
since presumably that default works for others.
