### PR TITLE
adds support for smtplib.SMTP_SSL

### DIFF
--- a/envelopes/conn.py
+++ b/envelopes/conn.py
@@ -40,13 +40,14 @@ class SMTP(object):
     """Wrapper around :py:class:`smtplib.SMTP` class."""
 
     def __init__(self, host=None, port=25, login=None, password=None,
-                 tls=False, timeout=None):
+                 tls=False, smtps=False, timeout=None):
         self._conn = None
         self._host = host
         self._port = port
         self._login = login
         self._password = password
         self._tls = tls
+        self._smtps = smtps
         self._timeout = timeout
 
     @property
@@ -67,11 +68,13 @@ class SMTP(object):
             except (AttributeError, smtplib.SMTPServerDisconnected):
                 pass
 
+            protocol = smtplib.SMTP_SSL if self._smtps else smtplib.SMTP
+
             if self._timeout:
-                self._conn = smtplib.SMTP(self._host, self._port,
-                                          timeout=self._timeout)
+                self._conn = protocol(self._host, self._port,
+                                      timeout=self._timeout)
             else:
-                self._conn = smtplib.SMTP(self._host, self._port)
+                self._conn = protocol(self._host, self._port)
 
         if self._tls:
             self._conn.starttls()

--- a/lib/testing.py
+++ b/lib/testing.py
@@ -144,6 +144,12 @@ class MockSMTP(object):
         self.__append_call('quit', [], dict())
 
 
+class MockSMTPSSL(MockSMTP):
+    """A class that mocks ``smtp.SMTP_SSL``."""
+
+    default_port = smtplib.SMTP_SSL_PORT
+
+
 class BaseTestCase(object):
     """Base class for Envelopes test cases."""
 
@@ -163,9 +169,15 @@ class BaseTestCase(object):
         self._orig_smtp = smtplib.SMTP
         smtplib.SMTP = MockSMTP
 
+        self._orig_smtp_ssl = smtplib.SMTP_SSL
+        smtplib.SMTP_SSL = MockSMTPSSL
+
     def _unpatch_smtplib(self):
         if hasattr(self, '_orig_smtp'):
             smtplib.SMTP = self._orig_smtp
+
+        if hasattr(self, '_orig_smtp_ssl'):
+            smtplib.SMTP_SSL = self._orig_smtp_ssl
 
     def _dummy_message(self):
         return dict({

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -30,6 +30,7 @@ This module contains test suite for the *SMTP* class.
 from envelopes.conn import SMTP
 from envelopes.envelope import Envelope
 from lib.testing import BaseTestCase
+from smtplib import SMTP_PORT, SMTP_SSL_PORT
 
 
 class Test_SMTPConnection(BaseTestCase):
@@ -38,7 +39,7 @@ class Test_SMTPConnection(BaseTestCase):
 
     def test_constructor(self):
         conn = SMTP('localhost', port=587, login='spam',
-                    password='eggs', tls=True, timeout=10)
+                    password='eggs', tls=True, smtps=True, timeout=10)
 
         assert conn._conn is None
         assert conn._host == 'localhost'
@@ -46,11 +47,12 @@ class Test_SMTPConnection(BaseTestCase):
         assert conn._login == 'spam'
         assert conn._password == 'eggs'
         assert conn._tls is True
+        assert conn._smtps is True
         assert conn._timeout == 10
 
     def test_constructor_all_kwargs(self):
         conn = SMTP(host='localhost', port=587, login='spam',
-                    password='eggs', tls=True)
+                    password='eggs', tls=True, smtps=True)
 
         assert conn._conn is None
         assert conn._host == 'localhost'
@@ -58,6 +60,7 @@ class Test_SMTPConnection(BaseTestCase):
         assert conn._login == 'spam'
         assert conn._password == 'eggs'
         assert conn._tls is True
+        assert conn._smtps is True
 
     def test_connect(self):
         conn = SMTP('localhost')
@@ -88,6 +91,17 @@ class Test_SMTPConnection(BaseTestCase):
         conn._connect()
         assert conn._conn is not None
         assert len(conn._conn._call_stack.get('starttls', [])) == 1
+
+    def test_connect_smtps(self):
+        conn = SMTP('localhost', smtps=False)
+        conn._connect()
+        assert conn._conn is not None
+        assert conn._conn.default_port == SMTP_PORT
+
+        conn = SMTP('localhost', smtps=True)
+        conn._connect()
+        assert conn._conn is not None
+        assert conn._conn.default_port == SMTP_SSL_PORT
 
     def test_connect_login(self):
         conn = SMTP('localhost')


### PR DESCRIPTION
Certain services require a secure connection to be established over SMTPS rather than use STARTTLS to upgrade a connection made over SMTP.  Python's smtplib provides classes for managing both kinds of connections, but envelopes only has support for SMTP.  I added an extra argument (`smtps`) to the declaration of the `Connection` class (defaulting to `False`), and select between using SMTP and SMTPS based upon its value.
