### PR TITLE
Allowed adding attachments from strings and streams

### DIFF
--- a/envelopes/__init__.py
+++ b/envelopes/__init__.py
@@ -27,7 +27,7 @@ envelopes
 Mailing for human beings.
 """
 
-__version__ = '0.4'
+__version__ = '0.5'
 
 
 from .conn import *

--- a/envelopes/envelope.py
+++ b/envelopes/envelope.py
@@ -274,7 +274,7 @@ class Envelope(object):
     def to_mime_message(self):
         """Returns the envelope as
         :py:class:`email.mime.multipart.MIMEMultipart`."""
-        msg = MIMEMultipart('alternative')
+        msg = MIMEMultipart('mixed')
         msg['Subject'] = self._header(self._subject or '')
 
         msg['From'] = self._encoded(self._addrs_to_header([self._from]))


### PR DESCRIPTION
I have added a new kwarg to the add_attachmen method 'data'. It can be a bytestring or a stream that contains the data to be added. This allows us to attach data that we don't have stored on the fs
