### PR TITLE
support non-ASCII characters

### DIFF
--- a/envelopes/envelope.py
+++ b/envelopes/envelope.py
@@ -314,8 +314,7 @@ class Envelope(object):
             email_encoders.encode_base64(part)
 
             part_filename = os.path.basename(self._encoded(file_path))
-            part.add_header('Content-Disposition', 'attachment; filename="%s"'
-                            % part_filename)
+            part.add_header('Content-Disposition', 'attachment', filename=("utf-8", None, part_filename))
 
             self._parts.append((mimetype, part))
 


### PR DESCRIPTION
Add Chinese attachment file name．
Receive the attachment display`tcmime.1771.1986.2204.bin`.
According to the official,
msg.add_header('Content-Disposition', 'attachment', filename=("utf-8", None, '哈哈.png'))
correct　display
But,on python2.7 can work.
I don't know why?
