### PR TITLE
From field in the mail headers can be different to the From in the envelope

### DIFF
--- a/envelopes/conn.py
+++ b/envelopes/conn.py
@@ -79,15 +79,16 @@ class SMTP(object):
         if self._login:
             self._conn.login(self._login, self._password or '')
 
-    def send(self, envelope):
+    def send(self, envelope, return_path=None):
         """Sends an *envelope*."""
         if not self.is_connected:
             self._connect()
 
         msg = envelope.to_mime_message()
+        smtp_from = return_path or msg["From"]
         to_addrs = [envelope._addrs_to_header([addr]) for addr in envelope._to + envelope._cc + envelope._bcc]
 
-        return self._conn.sendmail(msg['From'], to_addrs, msg.as_string())
+        return self._conn.sendmail(smtp_from, to_addrs, msg.as_string())
 
 
 class GMailSMTP(SMTP):


### PR DESCRIPTION
It's useful if you need to provide a bounce address: the bounce address is the From in the envelope. A 'Return-Path' in the e-mail headers will be ignored.

This PR provides the ability to setup a specific address. By default, the From in header is used so the library continue to be easy to use.